### PR TITLE
Add links section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@astrojs/mdx": "^4.3.13",
         "@astrojs/rss": "^4.0.15",
         "@astrojs/sitemap": "^3.7.0",
+        "@lucide/astro": "^0.577.0",
         "astro": "^5.18.0",
         "mermaid": "^11.13.0",
         "sharp": "^0.34.3"
@@ -1699,6 +1700,15 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
+    },
+    "node_modules/@lucide/astro": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/@lucide/astro/-/astro-0.577.0.tgz",
+      "integrity": "sha512-xZcdx+MyYXY74cBzFxr9N49SlofbGjCVD9GxJZcJA40PJvJSLWSeJpD9bgKFcZfFxf1QXkEYaR6BnCS+0lek8Q==",
+      "license": "ISC",
+      "peerDependencies": {
+        "astro": "^4 || ^5"
+      }
     },
     "node_modules/@mdx-js/mdx": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@astrojs/mdx": "^4.3.13",
     "@astrojs/rss": "^4.0.15",
     "@astrojs/sitemap": "^3.7.0",
+    "@lucide/astro": "^0.577.0",
     "astro": "^5.18.0",
     "mermaid": "^11.13.0",
     "sharp": "^0.34.3"

--- a/src/components/atoms/badge.astro
+++ b/src/components/atoms/badge.astro
@@ -1,0 +1,20 @@
+---
+interface Props {
+  label: string
+}
+
+const { label } = Astro.props
+---
+
+<span class="badge">{label}</span>
+
+<style>
+  .badge {
+    font-size: 0.75rem;
+    color: rgb(var(--gray));
+    background-color: rgb(var(--gray-light));
+    border-radius: 2rem;
+    padding: 0.1rem 0.55rem;
+    line-height: 1.6;
+  }
+</style>

--- a/src/components/atoms/badge.astro
+++ b/src/components/atoms/badge.astro
@@ -1,20 +1,31 @@
 ---
 interface Props {
-  label: string
+  variant?: "default" | "accent"
 }
 
-const { label } = Astro.props
+const { variant = "default" } = Astro.props
 ---
 
-<span class="badge">{label}</span>
+<span class:list={["badge", { "badge--accent": variant === "accent" }]}>
+  <slot />
+</span>
 
 <style>
   .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
     font-size: 0.75rem;
     color: rgb(var(--gray));
     background-color: rgb(var(--gray-light));
     border-radius: 2rem;
-    padding: 0.1rem 0.55rem;
-    line-height: 1.6;
+    padding: 0.25rem 0.55rem;
+    line-height: 1;
+  }
+
+  .badge--accent {
+    background-color: transparent;
+    border: 0.0625rem solid var(--accent);
+    color: var(--accent);
   }
 </style>

--- a/src/components/atoms/link-type-icon.astro
+++ b/src/components/atoms/link-type-icon.astro
@@ -1,5 +1,6 @@
 ---
 import { FileText, BookOpen, Play, GitFork } from "@lucide/astro"
+import Badge from "@/components/atoms/badge.astro"
 
 interface Props {
   type: "blog-post" | "book" | "video" | "repo"
@@ -7,25 +8,17 @@ interface Props {
 
 const { type } = Astro.props
 
-const icons = {
-  "blog-post": FileText,
-  "book": BookOpen,
-  "video": Play,
-  "repo": GitFork,
+const config = {
+  "blog-post": { Icon: FileText, label: "Blog Post" },
+  "book": { Icon: BookOpen, label: "Book" },
+  "video": { Icon: Play, label: "Video" },
+  "repo": { Icon: GitFork, label: "Repo" },
 }
 
-const Icon = icons[type]
+const { Icon, label } = config[type]
 ---
 
-<Icon size={16} aria-hidden="true" class="link-type-icon" />
-
-<style>
-  .link-type-icon {
-    display: inline-block;
-    vertical-align: middle;
-    position: relative;
-    top: -0.1em;
-    flex-shrink: 0;
-    color: rgb(var(--gray));
-  }
-</style>
+<Badge variant="accent">
+  <Icon size={11} aria-hidden="true" />
+  {label}
+</Badge>

--- a/src/components/atoms/link-type-icon.astro
+++ b/src/components/atoms/link-type-icon.astro
@@ -1,0 +1,31 @@
+---
+import { FileText, BookOpen, Play, GitFork } from "@lucide/astro"
+
+interface Props {
+  type: "blog-post" | "book" | "video" | "repo"
+}
+
+const { type } = Astro.props
+
+const icons = {
+  "blog-post": FileText,
+  "book": BookOpen,
+  "video": Play,
+  "repo": GitFork,
+}
+
+const Icon = icons[type]
+---
+
+<Icon size={16} aria-hidden="true" class="link-type-icon" />
+
+<style>
+  .link-type-icon {
+    display: inline-block;
+    vertical-align: middle;
+    position: relative;
+    top: -0.1em;
+    flex-shrink: 0;
+    color: rgb(var(--gray));
+  }
+</style>

--- a/src/components/molecules/internal-links.astro
+++ b/src/components/molecules/internal-links.astro
@@ -5,6 +5,7 @@ import HeaderLink from "@/components/atoms/header-link.astro"
 <div class="internal-links">
   <HeaderLink href="/blog">Blog</HeaderLink>
   <HeaderLink href="/projects">Side Projects</HeaderLink>
+  <HeaderLink href="/links">Links</HeaderLink>
   <HeaderLink href="/about">About</HeaderLink>
 </div>
 

--- a/src/components/molecules/link-card.astro
+++ b/src/components/molecules/link-card.astro
@@ -24,31 +24,33 @@ const dateStr = dateAdded.toLocaleDateString("en-US", {
 <li class="link-item" data-tags={JSON.stringify(tags)}>
   <div class="link-header">
     <a href={url} target="_blank" rel="noopener noreferrer" class="link-title">
-      {type && <LinkTypeIcon type={type} />}
       {title}
     </a>
     <div class="link-meta">
-      <a
-        href={archiveUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="archive-link"
-        title="View on Wayback Machine"
-      >
-        <svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true">
-          <path d="M22.667 22.884V24H1.333v-1.116zm-.842-1.675v1.396H2.175v-1.396zM4.233 6.14l.234.118.118 1.882.117 3.058v2.941l-.117 3.666-.02 2.47-.332.098H3.062l-.352-.098-.136-2.47-.118-3.646v-2.941l.118-3.078.107-1.892.244-.107zm16.842 0l.235.118.117 1.882.117 3.058v2.941l-.117 3.666-.02 2.47-.332.098h-1.171l-.352-.098-.137-2.47-.117-3.646v-2.941l.117-3.078.108-1.892.244-.107zm-11.79 0l.235.118.117 1.882.117 3.058v2.941l-.117 3.666-.02 2.47-.331.098H8.114l-.352-.098-.136-2.47-.117-3.646v-2.941l.117-3.078.107-1.892.244-.107zm6.457 0l.234.118.117 1.882.118 3.058v2.941l-.118 3.666-.019 2.47-.332.098H14.57l-.351-.098-.137-2.47-.117-3.646v-2.941l.117-3.078.108-1.892.244-.107zm6.083-2.511V5.58H2.175V3.628zM11.798 0l10.307 2.347-.413.723H1.951l-.618-.587Z"/>
-        </svg>
-        <span class="sr-only">View on Wayback Machine</span>
-      </a>
+      {type !== "video" && type !== "repo" && (
+        <a
+          href={archiveUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="archive-link"
+          title="View on Wayback Machine"
+        >
+          <svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true">
+            <path d="M22.667 22.884V24H1.333v-1.116zm-.842-1.675v1.396H2.175v-1.396zM4.233 6.14l.234.118.118 1.882.117 3.058v2.941l-.117 3.666-.02 2.47-.332.098H3.062l-.352-.098-.136-2.47-.118-3.646v-2.941l.118-3.078.107-1.892.244-.107zm16.842 0l.235.118.117 1.882.117 3.058v2.941l-.117 3.666-.02 2.47-.332.098h-1.171l-.352-.098-.137-2.47-.117-3.646v-2.941l.117-3.078.108-1.892.244-.107zm-11.79 0l.235.118.117 1.882.117 3.058v2.941l-.117 3.666-.02 2.47-.331.098H8.114l-.352-.098-.136-2.47-.117-3.646v-2.941l.117-3.078.107-1.892.244-.107zm6.457 0l.234.118.117 1.882.118 3.058v2.941l-.118 3.666-.019 2.47-.332.098H14.57l-.351-.098-.137-2.47-.117-3.646v-2.941l.117-3.078.108-1.892.244-.107zm6.083-2.511V5.58H2.175V3.628zM11.798 0l10.307 2.347-.413.723H1.951l-.618-.587Z" />
+          </svg>
+          <span class="sr-only">View on Wayback Machine</span>
+        </a>
+      )}
       <time class="link-date" datetime={dateAdded.toISOString().slice(0, 10)}>
         {dateStr}
       </time>
     </div>
   </div>
-  {tags.length > 0 && (
+  {(type || tags.length > 0) && (
     <div class="link-tags">
+      {type && <LinkTypeIcon type={type} />}
       {tags.map(tag => (
-        <Badge label={tag} />
+        <Badge>{tag}</Badge>
       ))}
     </div>
   )}
@@ -71,10 +73,17 @@ const dateStr = dateAdded.toLocaleDateString("en-US", {
 
   .link-header {
     display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 1rem;
-    flex-wrap: wrap;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  @media (min-width: 36rem) {
+    .link-header {
+      flex-direction: row;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 1rem;
+    }
   }
 
   .link-title {
@@ -83,9 +92,7 @@ const dateStr = dateAdded.toLocaleDateString("en-US", {
     color: var(--accent);
     text-decoration: none;
     line-height: 1.3;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
+    min-width: 0;
   }
 
   .link-title:hover {
@@ -96,7 +103,6 @@ const dateStr = dateAdded.toLocaleDateString("en-US", {
     font-size: 0.8rem;
     color: rgb(var(--gray));
     white-space: nowrap;
-    flex-shrink: 0;
   }
 
   .link-meta {

--- a/src/components/molecules/link-card.astro
+++ b/src/components/molecules/link-card.astro
@@ -1,0 +1,137 @@
+---
+import type { CollectionEntry } from "astro:content"
+import { render } from "astro:content"
+import Badge from "@/components/atoms/badge.astro"
+import LinkTypeIcon from "@/components/atoms/link-type-icon.astro"
+
+interface Props {
+  entry: CollectionEntry<"links">
+}
+
+const { entry } = Astro.props
+const { title, url, dateAdded, tags, type } = entry.data
+const { Content } = await render(entry)
+const archiveUrl = `https://web.archive.org/web/19700101000000/${url}`
+const hasBody = (entry.body ?? "").trim().length > 0
+const dateStr = dateAdded.toLocaleDateString("en-US", {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  timeZone: "UTC",
+})
+---
+
+<li class="link-item" data-tags={JSON.stringify(tags)}>
+  <div class="link-header">
+    <a href={url} target="_blank" rel="noopener noreferrer" class="link-title">
+      {type && <LinkTypeIcon type={type} />}
+      {title}
+    </a>
+    <div class="link-meta">
+      <a
+        href={archiveUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="archive-link"
+        title="View on Wayback Machine"
+      >
+        <svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true">
+          <path d="M22.667 22.884V24H1.333v-1.116zm-.842-1.675v1.396H2.175v-1.396zM4.233 6.14l.234.118.118 1.882.117 3.058v2.941l-.117 3.666-.02 2.47-.332.098H3.062l-.352-.098-.136-2.47-.118-3.646v-2.941l.118-3.078.107-1.892.244-.107zm16.842 0l.235.118.117 1.882.117 3.058v2.941l-.117 3.666-.02 2.47-.332.098h-1.171l-.352-.098-.137-2.47-.117-3.646v-2.941l.117-3.078.108-1.892.244-.107zm-11.79 0l.235.118.117 1.882.117 3.058v2.941l-.117 3.666-.02 2.47-.331.098H8.114l-.352-.098-.136-2.47-.117-3.646v-2.941l.117-3.078.107-1.892.244-.107zm6.457 0l.234.118.117 1.882.118 3.058v2.941l-.118 3.666-.019 2.47-.332.098H14.57l-.351-.098-.137-2.47-.117-3.646v-2.941l.117-3.078.108-1.892.244-.107zm6.083-2.511V5.58H2.175V3.628zM11.798 0l10.307 2.347-.413.723H1.951l-.618-.587Z"/>
+        </svg>
+        <span class="sr-only">View on Wayback Machine</span>
+      </a>
+      <time class="link-date" datetime={dateAdded.toISOString().slice(0, 10)}>
+        {dateStr}
+      </time>
+    </div>
+  </div>
+  {tags.length > 0 && (
+    <div class="link-tags">
+      {tags.map(tag => (
+        <Badge label={tag} />
+      ))}
+    </div>
+  )}
+  {hasBody && (
+    <div class="link-body">
+      <Content />
+    </div>
+  )}
+</li>
+
+<style>
+  .link-item {
+    padding: 1.25rem 0;
+    border-bottom: 0.0625rem solid rgb(var(--gray-light));
+  }
+
+  .link-item:first-child {
+    border-top: 0.0625rem solid rgb(var(--gray-light));
+  }
+
+  .link-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .link-title {
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: var(--accent);
+    text-decoration: none;
+    line-height: 1.3;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .link-title:hover {
+    text-decoration: underline;
+  }
+
+  .link-date {
+    font-size: 0.8rem;
+    color: rgb(var(--gray));
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .link-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-shrink: 0;
+  }
+
+  .archive-link {
+    color: rgb(var(--gray));
+    display: flex;
+    align-items: center;
+    transition: color 0.15s;
+  }
+
+  .archive-link:hover {
+    color: rgb(var(--gray-dark));
+  }
+
+  .link-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-top: 0.4rem;
+  }
+
+  .link-body {
+    margin-top: 0.6rem;
+    font-size: 0.95rem;
+    color: rgb(var(--gray-dark));
+    line-height: 1.6;
+  }
+
+  .link-body :global(p) {
+    margin: 0;
+  }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -32,4 +32,15 @@ const projects = defineCollection({
     }),
 })
 
-export const collections = { blog, projects, til }
+const links = defineCollection({
+  loader: glob({ base: "./src/content/links", pattern: "**/*.md" }),
+  schema: z.object({
+    title: z.string(),
+    url: z.string().url(),
+    dateAdded: z.coerce.date(),
+    tags: z.array(z.string()).default([]),
+    type: z.enum(["blog-post", "book", "video", "repo"]).optional(),
+  }),
+})
+
+export const collections = { blog, links, projects, til }

--- a/src/content/links/an-experiment-fighting-spam-on-public-forms-using-proof-of-work.md
+++ b/src/content/links/an-experiment-fighting-spam-on-public-forms-using-proof-of-work.md
@@ -1,0 +1,9 @@
+---
+title: "An experiment in fighting spam on public forms using “proof of work”"
+url: "https://blog.ovalerio.net/archives/2996"
+dateAdded: 2024-10-22
+tags: [spam, security, proof-of-work, web]
+type: "blog-post"
+---
+
+Proof of Work singing for its supper. Clever idea to combat Grey Goo Internet.

--- a/src/content/links/an-interactive-guide-to-svg-paths.md
+++ b/src/content/links/an-interactive-guide-to-svg-paths.md
@@ -1,0 +1,9 @@
+---
+title: "An Interactive Guide to SVG Paths"
+url: "https://www.joshwcomeau.com/svg/interactive-guide-to-paths/"
+dateAdded: 2025-08-22
+tags: [svg, web, explainer, interactive]
+type: "blog-post"
+---
+
+SVG paths and gcode are both marvels at encoding complex geometries with simple instructions. Thanks, Josh.

--- a/src/content/links/automated-hydroponic-system-build.md
+++ b/src/content/links/automated-hydroponic-system-build.md
@@ -1,0 +1,9 @@
+---
+title: "Automated Hydroponic System Build"
+url: "https://kylegabriel.com/projects/2020/06/automated-hydroponic-system-build.html"
+dateAdded: 2021-07-10
+tags: [diy, raspberry-pi, automation, hardware, gardening]
+type: "blog-post"
+---
+
+A boy can dream.

--- a/src/content/links/falsehoods-programmers-believe-about-addresses.md
+++ b/src/content/links/falsehoods-programmers-believe-about-addresses.md
@@ -1,0 +1,9 @@
+---
+title: "Falsehoods Programmers Believe About Addresses"
+url: "https://www.mjt.me.uk/posts/falsehoods-programmers-believe-about-addresses/"
+dateAdded: 2020-03-20
+tags: [falsehoods, internationalization, data-modeling, forms, classic]
+type: "blog-post"
+---
+
+Attempts to enforce strict namespacing on organic systems makes Jack a dull boy.

--- a/src/content/links/falsehoods-programmers-believe-about-names.md
+++ b/src/content/links/falsehoods-programmers-believe-about-names.md
@@ -1,0 +1,9 @@
+---
+title: "Falsehoods Programmers Believe About Names"
+url: "https://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/"
+dateAdded: 2020-03-20
+tags: [falsehoods, internationalization, data-modeling, ux, classic]
+type: "blog-post"
+---
+
+Sometimes Product asks, "How hard could it be to break `name` into `firstName` and `lastName`?

--- a/src/content/links/falsehoods-programmers-believe-about-time.md
+++ b/src/content/links/falsehoods-programmers-believe-about-time.md
@@ -1,0 +1,9 @@
+---
+title: "Falsehoods Programmers Believe About Time"
+url: "https://infiniteundo.com/post/25326999628/falsehoods-programmers-believe-about-time"
+dateAdded: 2020-03-20
+tags: [falsehoods, time, distributed-systems, testing, classic]
+type: "blog-post"
+---
+
+Sometimes devs haven't fully realized the horror that is time zones support. Lookin' at you, Kiribati.

--- a/src/content/links/grok-and-the-naked-king-argument.md
+++ b/src/content/links/grok-and-the-naked-king-argument.md
@@ -1,0 +1,9 @@
+---
+title: "Grok and the Naked King: The Ultimate Argument Against AI Alignment"
+url: "https://ibrahimcesar.cloud/blog/grok-and-the-naked-king/"
+dateAdded: 2025-12-26
+tags: [ai, alignment, politics, longreads, power]
+type: "blog-post"
+---
+
+Whoever owns the weights owns the values.

--- a/src/content/links/how-to-and-how-not-to-design-rest-apis.md
+++ b/src/content/links/how-to-and-how-not-to-design-rest-apis.md
@@ -1,0 +1,9 @@
+---
+title: "How to (and how not to) design REST APIs"
+url: "https://github.com/stickfigure/blog/wiki/How-to-(and-how-not-to)-design-REST-APIs"
+dateAdded: 2023-11-22
+tags: [api-design, rest, reference, antipatterns]
+type: "blog-post"
+---
+
+How to read someone's recommendations and interpretation of RESTful endpoints without getting tribal.

--- a/src/content/links/how-to-do-code-review-like-a-human.md
+++ b/src/content/links/how-to-do-code-review-like-a-human.md
@@ -1,0 +1,9 @@
+---
+title: "How to Do Code Reviews Like a Human (Part One)"
+url: "https://mtlynch.io/human-code-reviews-1/"
+dateAdded: 2017-10-15
+tags: [code-review, engineering-culture, communication, reference]
+type: "blog-post"
+---
+
+"Consider reading this and then changing everything about your PR."

--- a/src/content/links/ink.md
+++ b/src/content/links/ink.md
@@ -1,0 +1,9 @@
+---
+title: "Ink"
+url: "https://github.com/vadimdemedes/ink"
+dateAdded: 2023-05-08
+tags: [react, cli, tooling, open-source]
+type: "repo"
+---
+
+Ever asked yourself, "Can React Fiber do a CLI?"

--- a/src/content/links/it-matters-a-great-deal.md
+++ b/src/content/links/it-matters-a-great-deal.md
@@ -1,0 +1,9 @@
+---
+title: "It Matters a Great Deal"
+url: "https://www.youtube.com/watch?v=Y9LJqx2k9aI"
+dateAdded: 2026-03-04
+tags: [the-moth, storytelling, family, grief]
+type: "video"
+---
+
+Love your mom.

--- a/src/content/links/kafka-its-a-wonderful-life.md
+++ b/src/content/links/kafka-its-a-wonderful-life.md
@@ -1,0 +1,9 @@
+---
+title: "Kafka's It's a Wonderful Life"
+url: "https://www.youtube.com/watch?v=hwY-u1pFFdM"
+dateAdded: 2024-09-01
+tags: [short-film, comedy, kafka, absurdist]
+type: "video"
+---
+
+"The other girls found some beetles and moths you might like."

--- a/src/content/links/mit-15.401-finance-theory-1.md
+++ b/src/content/links/mit-15.401-finance-theory-1.md
@@ -1,0 +1,9 @@
+---
+title: "Finance Theory I"
+url: "https://www.youtube.com/watch?v=HdHlfiOAJyE&list=PLUl4u3cNGP63B2lDhyKOsImI7FjCf6eDW"
+dateAdded: 2008-12-01
+tags: [finance, economics, mit-ocw, lecture-series, financial-crisis]
+type: "video"
+---
+
+Intro to finance theory, taught blow for blow with the 2008 economic recession.

--- a/src/content/links/never-ignore-a-recruiter.md
+++ b/src/content/links/never-ignore-a-recruiter.md
@@ -1,0 +1,9 @@
+---
+title: "Career Advice Nobody Gave Me: Never Ignore a Recruiter"
+url: "https://index.medium.com/career-advice-nobody-gave-me-never-ignore-a-recruiter-4474eac9556"
+dateAdded: 2022-02-01
+tags: [career, job-search, negotiation, templates, salary]
+type: "blog-post"
+---
+
+Programmatic interaction can be constructive and pro-social.

--- a/src/content/links/pair-programming-antipatterns.md
+++ b/src/content/links/pair-programming-antipatterns.md
@@ -1,0 +1,9 @@
+---
+title: "Pair Programming Antipatterns"
+url: "https://tuple.app/pair-programming-guide/antipatterns"
+dateAdded: 2022-03-06
+tags: [pair-programming, engineering-culture, reference, antipatterns]
+type: "blog-post"
+---
+
+Make friends, build neat things, and avoid burnout with the wisdom of the Elders of the Internet.

--- a/src/content/links/payments-101-for-a-developer.md
+++ b/src/content/links/payments-101-for-a-developer.md
@@ -1,0 +1,9 @@
+---
+title: "Payments 101 for a Developer"
+url: "https://github.com/juspay/hyperswitch/wiki/Payments-101-for-a-Developer"
+dateAdded: 2023-04-26
+tags: [payments, fintech, reference, explainer]
+type: "blog-post"
+---
+
+A primer for another deceptively complex problem.

--- a/src/content/links/the-copenhagen-book.md
+++ b/src/content/links/the-copenhagen-book.md
@@ -1,0 +1,9 @@
+---
+title: "The Copenhagen Book"
+url: "https://thecopenhagenbook.com/"
+dateAdded: 2024-10-11
+tags: [auth, security, reference, web]
+type: "blog-post"
+---
+
+A deep dive into auth in web apps.

--- a/src/content/links/the-forest-king.md
+++ b/src/content/links/the-forest-king.md
@@ -1,0 +1,9 @@
+---
+title: "The Forest King"
+url: "https://www.youtube.com/watch?v=VtRwYS0h4Ao&pp=ygUPdGhlIGZvcmVzdCBraW5n"
+dateAdded: 2025-11-18
+tags: [animation, sci-fi, dystopia, short-film, cyberpunk]
+type: "video"
+---
+
+Snowcrash with more peer pressure. Someday the caps will dry out.

--- a/src/content/links/the-quitting-economy.md
+++ b/src/content/links/the-quitting-economy.md
@@ -1,0 +1,9 @@
+---
+title: "The Quitting Economy"
+url: "https://aeon.co/essays/how-work-changed-to-make-us-all-passionate-quitters"
+dateAdded: 2017-07-26
+tags: [work, neoliberalism, career, labor, longreads]
+type: "blog-post"
+---
+
+Loyalty belongs between humans.

--- a/src/content/links/tscircuit.md
+++ b/src/content/links/tscircuit.md
@@ -1,0 +1,9 @@
+---
+title: "tscircuit"
+url: "https://github.com/tscircuit/tscircuit"
+dateAdded: 2024-06-21
+tags: [react, electronics, hardware, open-source, eda]
+type: "repo"
+---
+
+Ever asked yourself, "Can React Fiber do a circuit diagram and generate PCB art?"

--- a/src/content/links/url-explained.md
+++ b/src/content/links/url-explained.md
@@ -1,0 +1,9 @@
+---
+title: "URL explained - The Fundamentals"
+url: "https://ittavern.com/url-explained-the-fundamentals/"
+dateAdded: 2023-05-08
+tags: [networking, web, explainer, reference]
+type: "blog-post"
+---
+
+Know your URLs from your URIs.

--- a/src/content/links/where-does-my-computer-get-the-time-from.md
+++ b/src/content/links/where-does-my-computer-get-the-time-from.md
@@ -1,0 +1,9 @@
+---
+title: "Where does my computer get the time from?"
+url: "https://dotat.at/@/2023-05-26-whence-time.html"
+dateAdded: 2023-10-05
+tags: [time, ntp, networking, explainer, history]
+type: "blog-post"
+---
+
+It's not just miliseconds since 1 January 1970.

--- a/src/content/links/which-color-scale-to-use-when-visualizing-data.md
+++ b/src/content/links/which-color-scale-to-use-when-visualizing-data.md
@@ -1,0 +1,9 @@
+---
+title: "Which color scale to use when visualizing data"
+url: "https://www.datawrapper.de/blog/which-color-scale-to-use-in-data-vis"
+dateAdded: 2021-03-17
+tags: [color, data-visualization, design, reference, accessibility]
+type: "blog-post"
+---
+
+A little Tufte, distilled.

--- a/src/pages/links/index.astro
+++ b/src/pages/links/index.astro
@@ -1,0 +1,114 @@
+---
+import { getCollection } from "astro:content"
+import BaseLayout from "@/components/layouts/base.astro"
+import LinkCard from "@/components/molecules/link-card.astro"
+
+const links = (await getCollection("links")).sort(
+  (a, b) => b.data.dateAdded.getTime() - a.data.dateAdded.getTime(),
+)
+
+const allTags = [...new Set(links.flatMap(link => link.data.tags))].sort()
+---
+
+<BaseLayout title="Links" description="Things worth reading, watching, or using">
+  <h1>Links</h1>
+  <p>Things I've read, watched, or used over the years.</p>
+
+  {allTags.length > 0 && (
+    <div class="tag-filters" role="group" aria-label="Filter by tag">
+      <button class="tag-btn tag-btn--active" data-tag="all">All</button>
+      {allTags.map(tag => (
+        <button class="tag-btn" data-tag={tag}>{tag}</button>
+      ))}
+    </div>
+  )}
+
+  <ul class="links-list">
+    {links.map(link => <LinkCard entry={link} />)}
+  </ul>
+
+  <p id="no-results" hidden>No links found for this tag.</p>
+</BaseLayout>
+
+<script>
+const filterBtns = document.querySelectorAll<HTMLButtonElement>(".tag-btn")
+const linkItems = document.querySelectorAll<HTMLElement>(".link-item")
+const noResults = document.getElementById("no-results")
+
+function filterByTag(tag: string) {
+  filterBtns.forEach((btn) => {
+    btn.classList.toggle("tag-btn--active", btn.dataset.tag === tag)
+  })
+
+  let visibleCount = 0
+  linkItems.forEach((item) => {
+    const tags: string[] = JSON.parse(item.dataset.tags ?? "[]")
+    const visible = tag === "all" || tags.includes(tag)
+    item.hidden = !visible
+    if (visible)
+      visibleCount++
+  })
+
+  if (noResults)
+    noResults.hidden = visibleCount > 0
+}
+
+filterBtns.forEach((btn) => {
+  btn.addEventListener("click", () => filterByTag(btn.dataset.tag ?? "all"))
+})
+</script>
+
+<style>
+  p {
+    color: rgb(var(--gray));
+    margin-bottom: 1.5rem;
+  }
+
+  .tag-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 2rem;
+  }
+
+  .tag-btn {
+    background: none;
+    border: 0.0625rem solid rgb(var(--gray-light));
+    border-radius: 2rem;
+    padding: 0.2rem 0.75rem;
+    font-size: 0.85rem;
+    font-family: inherit;
+    color: rgb(var(--gray));
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s, background-color 0.15s;
+    line-height: 1.6;
+  }
+
+  .tag-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  .tag-btn--active {
+    background-color: var(--accent);
+    border-color: var(--accent);
+    color: #fff;
+  }
+
+  .tag-btn--active:hover {
+    color: #fff;
+  }
+
+  .links-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  #no-results {
+    color: rgb(var(--gray));
+    font-size: 0.95rem;
+  }
+</style>


### PR DESCRIPTION
## Summary

- Adds a `/links` page with a curated links collection, client-side tag filtering, and top-level navigation
- Each link is a markdown file with `title`, `url`, `dateAdded`, `tags`, and optional `type` (`blog-post`, `book`, `video`, `repo`) in frontmatter; optional markdown body for notes
- New components: `Badge` atom (slot-based, with `default`/`accent` variants), `LinkTypeIcon` atom, `LinkCard` molecule
- Type badge renders inline with tags using the accent-outlined Badge variant
- Internet Archive link on each card (suppressed for `video` and `repo` types)
- Mobile-first responsive card header: stacks vertically, expands to single row at 36rem

## Test plan

- [ ] `/links` loads and displays all entries sorted newest-first
- [ ] Tag filter buttons show/hide entries correctly; "All" resets the view
- [ ] Type badges render with accent outline; tag badges render in gray
- [ ] Archive link present on blog-post and book entries, absent on video and repo
- [ ] Card header stacks on narrow viewports, goes single-line at wider widths
- [ ] Nav link highlights correctly when on `/links` or any sub-path

Made with [Cursor](https://cursor.com)