### PR TITLE
Add new-link script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "lint:fix": "eslint --fix .",
-    "til": "sh scripts/new-til.sh"
+    "til": "sh scripts/new-til.sh",
+    "link": "sh scripts/new-link.sh"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.3.13",

--- a/scripts/new-link.sh
+++ b/scripts/new-link.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+
+NAME="$1"
+
+if [ -z "$NAME" ]; then
+  echo "Usage: $0 <name>"
+  echo "Example: $0 my-cool-article"
+  exit 1
+fi
+
+FILE="src/content/links/${NAME}.md"
+
+if [ -f "$FILE" ]; then
+  echo "Link '${NAME}' already exists: ${FILE}"
+else
+  cat > "$FILE" <<EOF
+---
+title: ""
+url: ""
+dateAdded: $(date +%Y-%m-%d)
+tags: []
+type: ""
+---
+
+EOF
+  echo "Created ${FILE}"
+fi


### PR DESCRIPTION
## Summary
- Adds `scripts/new-link.sh` to scaffold new link entries with pre-filled frontmatter (title, url, dateAdded, tags, type)
- Adds `npm run link <name>` script to `package.json` for convenience


Made with [Cursor](https://cursor.com)