### PR TITLE
Add Paint Chips project and landing-page blurb

### DIFF
--- a/src/content/projects/paint-chips.md
+++ b/src/content/projects/paint-chips.md
@@ -1,0 +1,11 @@
+---
+title: "Paint Chips"
+url: "https://paintchips.app/"
+subtitle: "Sort the words, learn a thing, annoy your friends."
+---
+
+A grid of words that clearly belong together, if only you could work out how. Every tile looks like it might go anywhere, which is the whole problem.
+
+Paint Chips lays out an n×n board: n categories, n words each, all scrambled together. The goal is to sort every word back into the category it came from. There are thousands of words across hundreds of categories, so it's a good way to decompress and pick up a thing or two while you're at it. It plays especially well with a partner across the table while you wait for your food to arrive.
+
+The name is a throwback. The tiles reminded me of the paint chips my sister and I used to collect as kids and turn into little games of our own. Built to delight and annoy my friends and family in roughly equal measure. It has been a lot of fun.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,6 +14,9 @@ import LatestTil from "@/components/molecules/latest-til.astro"
       Based in Utah. Working on some things. Occasionally writing about them.
     </p>
     <p>
+      Lately that's <a target="_blank" href="https://paintchips.app/">Paint Chips</a>, a word-category matching game built to delight and annoy my friends and family. Bring a partner and your restaurant wait.
+    </p>
+    <p>
       In the area and want to grab lunch sometime? <a target="_blank" href="https://www.linkedin.com/in/christianbuchert/">Find me on LinkedIn</a>.
     </p>
   </section>


### PR DESCRIPTION
Adds Paint Chips (paintchips.app) to the projects section and a short blurb linking to it from the landing page.

- New project card at `src/content/projects/paint-chips.md` (text-only, matching the other cards)
- Landing-page intro blurb in `src/pages/index.astro`