### PR TITLE
Fix Vercel prod build (pnpm 9 workspace parse error)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
+# Not a real monorepo. This file exists so pnpm 11 (local) approves the
+# esbuild/sharp build scripts via `allowBuilds`. The `packages` glob is required
+# because Vercel builds with pnpm 9, which errors on a workspace file that has
+# no non-empty `packages` field ("packages field missing or empty"). The glob
+# matches nothing, so the repo stays effectively single-package.
+packages:
+  - "packages/*"
 allowBuilds:
   esbuild: true
   sharp: true


### PR DESCRIPTION
The prod deploy for the SPA-architecture merge failed at `pnpm install`:

```
ERROR  packages field missing or empty
Error: Command "pnpm install" exited with 1
```

**Cause:** version skew. Vercel builds with pnpm 9.x (it ignores our pinned `packageManager` because corepack isn't enabled on the project). pnpm 9 refuses a `pnpm-workspace.yaml` that has no non-empty `packages` field. That file exists only so local pnpm 11 approves the esbuild/sharp build scripts.

**Fix:** add a `packages` glob that matches nothing. Satisfies pnpm 9's check, keeps the repo effectively single-package, and pnpm 11 still honors `allowBuilds`.

Verified locally: clean `rm -rf node_modules && pnpm install` approves builds (no ignored-scripts error), sharp + esbuild build, `pnpm build` green (8 pages).

Alternative long-term fix (not done here): enable corepack on the Vercel project (`ENABLE_EXPERIMENTAL_COREPACK=1`) so it uses pnpm 11 everywhere — needs a dashboard/env change.