### PR TITLE
Fix mermaid ELK diagrams hanging in production

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,4 +13,21 @@ export default defineConfig({
       theme: "github-dark",
     },
   },
+  vite: {
+    build: {
+      rollupOptions: {
+        output: {
+          // Keep all of elkjs (mermaid's ELK layout) in one chunk. elkjs runs
+          // its layout in an in-thread "web worker" whose dispatcher and payload
+          // reference each other; when Rollup splits them across chunks (only
+          // happens once mermaid's large graph is in the bundle), elk.layout()
+          // never resolves, so mermaid.run() hangs and the diagram renders empty
+          // in production. Works in `astro dev` (unbundled) either way.
+          manualChunks(id) {
+            if (id.includes("elkjs") || id.includes("layout-elk")) return "elk"
+          },
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Problem

The ELK-laid-out mermaid diagram in `mermaid.astro` never renders in production (e.g. the [SPA architecture post](https://www.christianbuchert.com/blog/2026-07-16-spa-architecture/)) — it leaves an empty 150px SVG. It renders fine in `astro dev`.

## Root cause

elkjs (mermaid's ELK layout engine) runs its layout in an in-thread "web worker" — a dispatcher object and a layout payload that reference each other. Once mermaid's large module graph is in the bundle, Rollup's code-splitting scatters those two pieces across **separate chunks**, and `elk.layout()` never resolves. So `mermaid.run()` hangs forever → the diagram never draws and the component's pan/zoom wiring never runs. No console error, just a silently dead promise.

Only reproduces in production builds; `astro dev` serves modules unbundled, so no split happens.

## Fix

Force all elkjs / `@mermaid-js/layout-elk` code into a single chunk via `manualChunks`, keeping the in-thread worker intact.

## Verification

Clean `pnpm build` + `astro preview`, checked in a real browser: 22 nodes, 27 edges, pan/zoom viewport, and the Code/Preview toggle all work — identical to `astro dev`. Confirmed the default (dagre) layout was never affected.